### PR TITLE
Add EasyFXML to frameworks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [DataFX](https://github.com/guigarage/DataFX) - DataFX is a JavaFX frameworks that provides additional features to create MVC based applications in JavaFX by providing routing and a context for CDI.
 - [Dolphin Platform](https://github.com/canoo/dolphin-platform) - Dolphin Platform is a client / server frameworks that provides a async communication between a server and a client based on the remote presentation model pattern
 - [EasyBind](https://github.com/TomasMikula/EasyBind) - EasyBind leverages lambdas to reduce boilerplate when creating custom bindings.
+- [EasyFXML](https://github.com/Tristan971/EasyFXML) - EasyFXML is a fully-featured opinionated JavaFX framework based 
+on Vavr and Spring Boot which manages most of the annoying boilerplate that comes with JavaFX. [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 - [FXGL](http://almasb.github.io/FXGL/) - JavaFX Game Development Framework
 - [Griffon](http://griffon-framework.org/) - Next generation desktop application development platform for the JVM. [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 - [JacpFX](http://jacpfx.org/) - An UI application framework based on JavaFX
@@ -101,8 +103,6 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [ReduxFX](https://github.com/netopyr/reduxfx) - Functional Reactive Programming (FRP) for JavaFX inspired by the JavaScript library Redux.js
 - [ScalaFX](http://www.scalafx.org/) - simplifies creation of JavaFX-based user interfaces in Scala
 - [TornadoFX](https://github.com/edvin/tornadofx) - Lightweight JavaFX Framework for Kotlin
-- [EasyFXML](https://github.com/Tristan971/EasyFXML) - EasyFXML is a fully-featured opinionated JavaFX framework based 
-on Vavr and Spring Boot which manages most of the annoying boilerplate that comes with JavaFX. [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Books
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [ReduxFX](https://github.com/netopyr/reduxfx) - Functional Reactive Programming (FRP) for JavaFX inspired by the JavaScript library Redux.js
 - [ScalaFX](http://www.scalafx.org/) - simplifies creation of JavaFX-based user interfaces in Scala
 - [TornadoFX](https://github.com/edvin/tornadofx) - Lightweight JavaFX Framework for Kotlin
+- [EasyFXML](https://github.com/Tristan971/EasyFXML) - EasyFXML is a fully-featured opinionated JavaFX framework based 
+on Vavr and Spring Boot which manages most of the annoying boilerplate that comes with JavaFX. [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Books
 


### PR DESCRIPTION
Although the documentation itself might be improved upon (it is already somewhat comprehensive for basic usage, and comes with a sample real-life project in the form of a Twitter client I wrote with it), the code itself is very largely documented and thoroughly tested (94%-ish coverage) and based on reliable and mature libraries (Spring Boot and Vavr).

Also I put it on the bottom as per `CONTRIBUTING.md`'s rules, but the category appears to be alphabetically sorted, which seems kind of odd to do here?

If any more information is required don't hesitate to ask!