### PR TITLE
added JFXNodeMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [JavaFXPorts](http://gluonhq.com/labs/javafxports/) - JavaFXPorts is the open source project that brings Java and JavaFX to mobile and embedded hardware, including iPhone, iPad, Android devices, and the Raspberry Pi.
 - [JCSG](https://github.com/miho/JCSG) - Java implementation of BSP based CSG (Constructive Solid Geometry)
 - [JFoenix](http://www.jfoenix.com/) - JavaFX Material Design Library. JFoenix is an open source Java library, that implements Google Material Design using Java components.
+- [JFXNodeMapper](https://github.com/CaptainParanoid/JFXNodeMapper) - Javafx Node mapping to various data formats like csv,xml,json and resultset.
 - [JFXScad](https://github.com/miho/JFXScad) - JavaFX 3D Printing IDE based on JCSG.
 - [JFXtras](http://jfxtras.org/) - A supporting library for JavaFX, containing helper classes, extended layouts, controls and other interesting widgets.
 - [JideFX](https://github.com/jidesoft/jidefx-oss)- JideFX Common Layer is a collection of various extensions and utilities for to JavaFX platform. The JideFX Common Layer is the equivalent to the JIDE Common Layer in the JIDE components for Swing.


### PR DESCRIPTION
JFXNodeMapper is a simple lightweight library that maps data formats like JSON, ResulSet, CSV, and XML to JavaFX nodes based on their ids. Custom mapping based on event listeners are also available for nodes that use Custom types.
JFXNodeMapper focuses on small projects whose sole purpose is just displaying data from a server or A local DB. Upcoming features include reverse mapping,  i.e generates CSV, XML, JSON from node values.