### PR TITLE
Add wordagam to the list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [VWorkflows](https://github.com/miho/VWorkflows) - Interactive flow/graph visualization for building domain specific visual programming environments. Provides UI bindings for JavaFX.
 - [Webview Debugger](https://github.com/vsch/Javafx-WebView-Debugger) - JavaFx WebView debugging with Chrome Dev tools.
 - [WellBehavedFX](https://github.com/TomasMikula/WellBehavedFX) - Composable event handlers and skin scaffolding for JavaFX controls.
-
+- [Wordagam](https://github.com/gravetii/wordagam) - A fun little word game built with openjfx.
 
 ## Frameworks
 - [afterburner.fx](http://afterburner.adam-bien.com/) - afterburner.fx is a minimalistic (3 classes) JavaFX MVP framework based on Convention over Configuration and Dependency Injection.


### PR DESCRIPTION
Wordagam is a fun word game built in JavaFX. Users are given a 4x4 grid of letters and the goal is to form as many words as they can within a configurable time limit.