### PR TITLE
Add FXTrayIcon project

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [FXLauncher](https://github.com/edvin/fxlauncher) - Auto updating launcher for JavaFX Applications. Combined with JavaFX native packaging, you get a native installer with automatic app updates.
 - [FXParallax](https://github.com/dukke/FXParallax) - Parallax framework for Java (JavaFX).
 - [FXRibbon](https://github.com/dukke/FXRibbon) - Microsoft like Ribbon control for Java (JavaFX).
+- [FXTrayIcon](https://github.com/dustinkredmond/FXTrayIcon) - System TrayIcon implementation for JavaFX that allows developers to use native JavaFX MenuItems and not have to worry with AWT or Swing.
 - [FXValidation](https://github.com/dukke/FXValidation) - Validation support for Java (JavaFX).
 - [FXyz](https://github.com/Birdasaur/FXyz) - F(X)yz is a new JavaFX 3D library that provides additional primitives, composite objects, controls and data visualizations that the base JavaFX 8 3D packages do not have.
 - [GemsFX](https://github.com/dlsc-software-consulting-gmbh/GemsFX) - A small library with useful controls: an on-screen keyboard, a PDF viewer control, and some more.


### PR DESCRIPTION
My project (FXTrayIcon) has started to gather some popularity. Now that I'm actively maintaining it and pushing releases to Maven Central, I thought I would add.

FXTrayIcon is an implementation for cross-platform system tray icons. A developer can use JavaFX APIs that they are familiar with. FXTrayIcon converts the JavaFX MenuItem and Menus into AWT menu items, so a JavaFX developer doesn't need to learn AWT or Swing to implement tray icons.

The project is currently built and tested on Java 8, but plans to modularize and release a version for JDK9+ will be carried out this week.