### PR TITLE
Added MaterialFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [Kubed](https://github.com/hudsonb/kubed) - A port of the popular Javascript library D3.js to Kotlin/JavaFX.
 - [Lib-Tile](https://github.com/Naoghuman/lib-tile) - Lib-Tile is a multi Maven project written in JavaFX and NetBeans IDE 8.0.2 and provides the functionalities to use and handle easily Tiles in your JavaFX application.
 - [LiveDirsFX](https://github.com/TomasMikula/LiveDirsFX) - Directory tree model for JavaFX that watches the filesystem for changes.
+- [MaterialFX](https://github.com/palexdev/MaterialFX) - A new well documented and actively developed library which brings material design components to JavaFX and much more.
 - [Medusa](https://github.com/HanSolo/Medusa) - A JavaFX library for Gauges. The main focus of this project is to provide Gauges that can be configured in multiple ways.
 - [MigPane](http://miglayout.com) - MigLayout can produce flowing, grid based, absolute (with links), grouped and docking layouts.
 - [NetBeansIDE-AfterburnerFX-Plugin](https://github.com/Naoghuman/NetBeansIDE-AfterburnerFX-Plugin) - The NetBeansIDE-AfterburnerFX-Plugin is a NetBeans IDE plugin which supports the file generation in convention with the library afterburner.fx in a JavaFX project.


### PR DESCRIPTION
[MaterialFX](https://github.com/palexdev/MaterialFX)
Born as an alternative for the popular JFoenix library which is not maintained anymore and too buggy especially for newer versions of Java, MaterialFX maintains the same base goal, making JavaFX's controls better both in appearance and in functionality, but also brings a lot of new features.
New utilities from StringUtils to JavaFX utils such as: NodeUtils, LabelUtils, DragResizer and so on.
Controls built from scratch: in my library there is the concept of legacy and "brand new". Legacy controls are controls which extend JavaFX's ones but with a modern design and even new functionalities. The "brand new" controls are controls which extends the base class Control, all the functionalities are re-defined from scratch, the advantage of this approach is that I have full control on the source code, so I can bring more easily new features and bug fixes and even improve them in performance.
Some of these controls are: list views based on the popular Flowless, new TreeViews (will be reworked probably for better performance), table views, even context menus, and so on.