### PR TITLE
Replaced packaging article with updated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,10 +251,10 @@ We talk about the status of JavaFX on Mobile, and about the options for running 
 - [Building a JavaFX Search Bar](https://vocabhunter.github.io/2017/01/15/Search-Bar.html) - How to add a search bar to your JavaFX user interface. The article is based on a real application and includes links to all of the source code.
 - [Dependency Injection in JavaFX](https://vocabhunter.github.io/2016/11/13/JavaFX-Dependency-Injection.html) - A guide to implementing Dependency Injection in a JavaFX application.
 - [How JavaFX was used to build a desktop application](https://medium.com/techking/how-javafx-was-used-to-build-a-desktop-application-7d4c680d8dc) - A look at some of the features of JavaFX and how they were used in building an application.  The article includes links to all of the source code on GitHub. 
+- [Installable Java Apps with jpackage](https://vocabhunter.github.io/2021/07/10/installable-java-apps-with-jpackage.html) - How to create installable bundles for your JavaFX application for Mac, Linux and Windows using jpackage.
 - [JavaFX 8 Refcard](https://dzone.com/refcardz/javafx-8-1) - Gives you what you need to start using the powerful JavaFX 8 UI and graphics tool with code snippets and visual examples of shapes and controls.
 - [JavaFX Refcard](https://dzone.com/refcardz/getting-started-javafx) - Gets you started with JavaFX, which makes it easier to build better RIAs with graphics, animation, and media.
 - [User Interface Testing with TestFX](https://vocabhunter.github.io/2016/07/27/TestFX.html) - A guide to using TestFX to automate JavaFX user interface testing.
-- [Using the Java Packager with JDK 11](https://medium.com/@adam_carroll/java-packager-with-jdk11-31b3d620f4a8) - How to create installable bundles for your JavaFX application for Mac, Linux and Windows using the Java Packager on JDK 11.
 
 ## Real World Examples
 *Real World Examples of JavaFX and Applications*


### PR DESCRIPTION
I've replaced my old article [Using the Java Packager with JDK 11](https://medium.com/@adam_carroll/java-packager-with-jdk11-31b3d620f4a8) with my new version [Installable Java Apps with jpackage](https://vocabhunter.github.io/2021/07/10/installable-java-apps-with-jpackage.html).  The old version was based on using a pre-release Java Packager and the new article is fully updated to use the production-ready _jpackage_ that now ships with JDK 16.