### PR TITLE
Add WebFX (JavaFX transpiler project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [UndoFX](https://github.com/TomasMikula/UndoFX) - Undo manager for JavaFX.
 - [Update4j](https://github.com/update4j/update4j) - Auto-updater and launcher for your distributed applications. Built with Java 9's module system in mind.
 - [VWorkflows](https://github.com/miho/VWorkflows) - Interactive flow/graph visualization for building domain specific visual programming environments. Provides UI bindings for JavaFX.
+- [WebFX](https://webfx.dev) - A JavaFX application transpiler. Write your Web Application in JavaFX and WebFX will transpile it in pure JS.
 - [Webview Debugger](https://github.com/vsch/Javafx-WebView-Debugger) - JavaFx WebView debugging with Chrome Dev tools.
 - [WellBehavedFX](https://github.com/TomasMikula/WellBehavedFX) - Composable event handlers and skin scaffolding for JavaFX controls.
 - [Wordagam](https://github.com/gravetii/wordagam) - A fun little word game built with openjfx.


### PR DESCRIPTION
hi there,

I'm the maintainer of this project.

> include a link to the package

I linked the project to the [website](https://webfx.dev), but if you prefer, here is the [GitHub repository](https://github.com/webfx-project/webfx) 


> why it should be included

I think people will be interested in the project.
It's still in the incubation phase, with still a lot to do, but also a lot already done.
Even at this stage people can start using it (there is a getting started guide in the [documentation](https://docs.webfx.dev)) and already create nice Web Apps (as demonstrated by the website and the [demos](https://github.com/webfx-demos))

I haven't made any official communication yet, so this is my first public one!
It's a free, open source project, and I will try building a community around it.
So, let's start here 🤞 

Can you please add it to the list? 🙏 
Thank you!