### PR TITLE
Add AtlantaFX resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A curated list of awesome JavaFX frameworks, libraries, books etc... .
 - [AnchorFX](https://github.com/alexbodogit/AnchorFX) - Docking framework for JavaFX platform.
 - [Animated](https://github.com/iAmGio/animated) - Implicit animations for JavaFX, inspired by Flutter.
 - [AnimateFX](https://github.com/Typhon0/AnimateFX) - A JavaFX library containing ready-to-use animations.
+- [AtlantaFX](https://github.com/mkpaz/atlantafx) - Modern JavaFX CSS theme collection with additional controls.
 - [assertj-javafx](https://github.com/lestard/assertj-javafx) - AssertJ assertions for JavaFX Properties and Bindings.
 - [BootstrapFX](https://github.com/aalmiray/bootstrapfx/) - BootstrapFX is a partial port of Twitter Bootstrap for JavaFX.
 - [CalendarFX](https://github.com/dlemmermann/CalendarFX) - CalendarFX is a calendar framework for JavaFX 8. It contains a set of professional custom controls, which can be used to implement a calendar UI for any kind of application.


### PR DESCRIPTION
Adds [AtlantaFX](https://github.com/mkpaz/atlantafx) to the Libraries, Tools and Projects section.

AtlantaFX is a modern JavaFX CSS theme collection with additional controls, so it fits the Awesome JavaFX resource list.
